### PR TITLE
Fix gitfile path

### DIFF
--- a/gitfile.sh
+++ b/gitfile.sh
@@ -7,6 +7,7 @@ function cloneRepo
   SOURCE=${1}
   VERSION=${2}
   GIT_CLONE_PATH=${3//\~/$HOME}
+  echo "${SOURCE}"
   if [ ! -d "${GIT_CLONE_PATH}" ]; then
     git clone "${SOURCE}" ${GIT_CLONE_PATH} -q
   fi

--- a/gitfile.sh
+++ b/gitfile.sh
@@ -2,6 +2,21 @@
 
 set -euo pipefail
 
+function printHelpText
+{
+  echo "Usage:"
+  echo "  ${0} [OPTIONS]"
+  echo ""
+  echo "application Options:"
+  echo "  -p, --default-clone-path= Default path to git clone into (default: ./)"
+  echo "  -f, --gitfile= File path to the Gitfile (default: ./gitfile)"
+  echo ""
+  echo "Help Options:"
+  echo "  -h, --help            Show this help message and exit"
+  echo ""
+  exit 0
+}
+
 function cloneRepo
 {
   SOURCE=${1}
@@ -46,15 +61,23 @@ function parseYaml
 }
 
 DEFAULT_GIT_CLONE_PATH="."
-if [ "$#" -eq 1 ]; then
-  DEFAULT_GIT_CLONE_PATH=${1%/}
-fi
-
-
 YAML_FILE="./.gitfile"
-if [ "$#" -eq 2 ]; then
-  YAML_FILE="${2}"
-fi
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p) DEFAULT_GIT_CLONE_PATH="${2%/}"; shift 2;;
+    -f) YAML_FILE="$2"; shift 2;;
+
+    --default-clone-path=*) DEFAULT_GIT_CLONE_PATH="${1#*=}"; shift 1;;
+    --gitfile=*) YAML_FILE="${1#*=}"; shift 1;;
+    --default-clone-path|--gitfile) echo "$1 requires an argument" >&2; exit 1;;
+
+    -h) printHelpText;;
+    --help) printHelpText;;
+
+    -*) echo "unknown option: $1" >&2; exit 1;;
+    *) handle_argument "$1"; shift 1;;
+  esac
+done
 
 if [ ! -f "${YAML_FILE}" ]; then
   echo "[ERROR] '${YAML_FILE}' does not exist"

--- a/gitfile.sh
+++ b/gitfile.sh
@@ -61,4 +61,5 @@ if [ ! -f "${YAML_FILE}" ]; then
 fi
 
 cd "$(dirname "${YAML_FILE}")"
+YAML_FILE="./$(echo ${YAML_FILE} | rev | cut -d "/" -f 1 | rev)"
 parseYaml ${YAML_FILE} ${DEFAULT_GIT_CLONE_PATH}

--- a/gitfile.sh
+++ b/gitfile.sh
@@ -25,11 +25,11 @@ function cloneRepo
 
 function parseYaml
 {
-  YAML_FILE=${1}
+  YAML_FILE_CONTENT=$(cat ${1} | egrep -v "^\s*#")
   DEFAULT_GIT_CLONE_PATH=${2}
-  LAST_LINE_NUMBER="$(wc -l ${YAML_FILE} | awk '{print $1}')"
-  mapfile -t LINE_NUMBERS < <(cat -n ${YAML_FILE} | egrep -v "source:|version:|path:" | egrep "[0-9]{1,10}.*:\s*$" | awk '{print $1}')
-  mapfile -t DIR_NAMES  < <(cat -n ${YAML_FILE} | egrep -v "source:|version:|path:" | egrep "[0-9]{1,10}.*:\s*$" | awk '{print $2}')
+  LAST_LINE_NUMBER="$(echo "${YAML_FILE_CONTENT}" | wc -l | awk '{print $1}')"
+  mapfile -t LINE_NUMBERS < <(echo "${YAML_FILE_CONTENT}" | cat -n | egrep -v "source:|version:|path:" | egrep "[0-9]{1,10}.*:\s*$" | awk '{print $1}')
+  mapfile -t DIR_NAMES  < <(echo "${YAML_FILE_CONTENT}" | cat -n | egrep -v "source:|version:|path:" | egrep "[0-9]{1,10}.*:\s*$" | awk '{print $2}')
   for (( i=0; i < ${#LINE_NUMBERS[@]}; ++i ))
   do
     FROM=$(expr ${LINE_NUMBERS[$i]} + 1)
@@ -37,9 +37,9 @@ function parseYaml
     if [ "$i" -ne "$(expr ${#LINE_NUMBERS[@]} - 1 )" ]; then
       TO=$(expr ${LINE_NUMBERS[$i + 1]} - 1)
     fi
-    SOURCE=$(sed -n "${FROM},${TO}p" ${YAML_FILE} | grep "source:" | awk '{print $2}' | cut -d'"' -f2)
-    VERSION=$(sed -n "${FROM},${TO}p" ${YAML_FILE} | grep "version:" | awk '{print $2}' | cut -d'"' -f2 || echo "master")
-    GIT_CLONE_PATH=$(sed -n "${FROM},${TO}p" ${YAML_FILE} | grep "path:" | awk '{print $2}' | cut -d'"' -f2 || echo "${DEFAULT_GIT_CLONE_PATH}")
+    SOURCE=$(echo "${YAML_FILE_CONTENT}" | sed -n "${FROM},${TO}p" | grep "source:" | awk '{print $2}' | cut -d'"' -f2)
+    VERSION=$(echo "${YAML_FILE_CONTENT}" | sed -n "${FROM},${TO}p" | grep "version:" | awk '{print $2}' | cut -d'"' -f2 || echo "master")
+    GIT_CLONE_PATH=$(echo "${YAML_FILE_CONTENT}" | sed -n "${FROM},${TO}p" | grep "path:" | awk '{print $2}' | cut -d'"' -f2 || echo "${DEFAULT_GIT_CLONE_PATH}")
     cloneRepo ${SOURCE} ${VERSION} ${GIT_CLONE_PATH%/}/${DIR_NAMES[$i]%:}
   done
 }


### PR DESCRIPTION
- adds cli arguments
  - `-h, --help` display help text
  - `-p, --default-clone-path` overwrite default clone path (default: ./)
  - `-f, --gitfile` overwrite default gitfile path (default: ./.gitfile)
- adds help text
- fixes working directory context problem with gitfile after calling ` cd "$(dirname "${YAML_FILE}")"` in line 87
- comments with `#` will now correctly be ignored
- `source` will now displayed while looping over the .gitfile to indicate progress