### PR TITLE
initial release changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## [Unreleased] - TBD
+- no changes
+
+## [1.0.0] - 2019-10-27
+- initial release
+- MIT License
+- includes README.md and CHANGELOG.md
+- includes Makefile for test and install
+  - `make all`
+  - `make test`
+  - `make install`
+- initial functionality includes
+  - parsing of `yaml`-like .gitfile
+    - source
+    - path
+    - version
+    - supports comments with `#`
+  - cli paramters for
+    - help (-h/--help)
+    - configuring .gitfile location (-f/--gitfile)
+    - configuring default clone path (-p/--default-clone-path)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+all:
+	${MAKE} test
+	${MAKE} install
+
 test:
-		docker-compose up test
+		docker-compose up --exit-code-from test test
 
 install:
 		cp ./gitfile.sh /usr/local/bin/gitfile

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# Gitfile
+
+Gitfile is a MIT-Licensed Bash-script written in less than 100 lines to manage git repositores. 
+
+Originally written as a replacement for terraform module managers like https://github.com/coretech/terrafile and https://github.com/devopsmakers/xterrafile 
+
+Main reasons for the rewrite were:
+ - both written in Go with dependencies for a job that can be done in bash in less than 100 lines
+ - both always delete and re-clone the repository on execution
+ - both always delete the path recursively (they seriously delete your working directory if it's part of the path) which makes it impossible for directory structures like:
+   ```shell script
+   workspace
+   ├── moduleA
+   │   ├── main.tf
+   ├── moduleB
+   │   ├── main.tf
+   |   ├── moduleA.tf
+   ├── moduleC
+   │   ├── main.tf
+   │   ├── moduleA.tf
+   │   ├── moduleB.tf
+   ```
+
+`Gitfile` ended up beeing a more general approach that enables git management in general
+
+ 
+## Features
+ - doesn't delete your directories (looking at you `terrafile` tools -.-*)
+ - clones repository only if it hasn't been cloned already
+   - incremental changes are retrieved with fetch/checkout/pull
+ - fetch/checkout/pull are only executed if there are no changes in the local repository
+ - updates remote ULR if it changes (i.e. repo moved from github to self hosted domain)
+ 
+## Usage in automation
+
+In most cases you should be able to use the gitfile locally and in automation in exactly the same way.
+Nonetheless there are some use cases where you might prefer to Download your repository in automation using HTTPS instead of SSH or vice versa. 
+Simply re-configure git in your pipeline to switch from http cloning to ssh cloning:
+```shell script
+git config --global url.ssh://git@github.com/.insteadOf https://github.com/
+```
+
+## Install
+
+```shell script
+git clone https://github.com/Bobonium/gitfile.git
+cd gitfile
+make install
+```
+
+or alternatively:
+```shell script
+curl -L https://raw.githubusercontent.com/Bobonium/gitfile/master/gitfile.sh > /usr/local/bin/gitfile
+```
+
+#### dependencies:
+ - git
+ - openssh-client 
+ - make (for test/install)
+  
+
+## Use
+
+#### Command overview
+
+```shell script
+#quick-start
+cd ~/workspace/github/Bobonium/gitfile/
+gitfile
+```
+
+```shell script
+#print help text
+gitfile -h #--help
+#path/filename to parse as gitfile (default: ./.gitfile)
+gitfile -f /path/to/gitfile #--gitfile ->
+#path to store repos without explicit `path` (default: ./)
+gitfile -p /default/clone/path #--default-clone-path  
+```
+
+#### .gitfile format
+
+This is only a YAML-like format! gitfile does not use a full blown yaml parser, but instead only implemented the minimal requirements through some shell commands. 
+Feel free to create an Issue/Pull request if you find a problem with the parsing (or anything else of course).
+
+```yaml
+#required: repo will be cloned into dir with this name
+gitfile:
+    #required: clone URL (can be either http(s) or ssh)
+    source: "https://github.com/Bobonium/gitfile.git"
+    #optional: path to clone the repository into (default taken from gitfile command)
+    #relative path values are always relative to the path of the .gitfile
+    path: ~/workspace/github/Bobonium/
+    #optional: version to checkout (defaults to master)
+    #tags, branch names and commit hases are all valid values
+    #if you can run `git checkout $VERSION` it's valid
+    version: master
+```
+
+#### Release Cycle:
+
+Master branch will always be the current release; if it's good enough to merge, it's good enough to be released

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,11 @@ version: "2"
 services:
   test:
     image: bash:5
-    working_dir: /root/workspace/
+    working_dir: /root/workspace/gitfile/
     volumes:
       - ~/.ssh/:/root/.ssh/
-      - ./:/root/workspace/github/Bobonium/gitfile/
-      - ./gitfile.sh:/usr/local/bin/gitfile
+      - ./:/root/workspace/gitfile/
     command:
       - bash
       - -c
-      - "apk update > /dev/null 2>&1 && apk add git openssh-client > /dev/null 2>&1 && gitfile -f ./github/Bobonium/gitfile/.gitfile"
+      - "apk update > /dev/null 2>&1 && apk add git openssh-client make > /dev/null 2>&1 && make install && gitfile -f ./.gitfile"


### PR DESCRIPTION
- add README.md
- add CHANGELOG.md
- add `make all`
- `make test` now properly fails if docker-compose exit code is non-zero
- running `docker-compose up` or `make test` will no longer pull changes into the working directory